### PR TITLE
silly correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git clone https://github.com/MuammerBay/so-arm101-ros2-bridge.git
 cd so-arm101-ros2-bridge
 
 # Build ROS2 workspace
-colcon build --packages-select join tstatereader
+colcon build --packages-select jointstatereader
 
 # Source workspace
 source install/setup.bash


### PR DESCRIPTION
Just delete the space in the node name 'jointstatereader' in the README.md line 38